### PR TITLE
Score changes, Level changes

### DIFF
--- a/lib/game/objects/level.dart
+++ b/lib/game/objects/level.dart
@@ -9,106 +9,111 @@ class Levels {
   Levels(this._dimensions);
 
   LevelConfiguration getLevel(int level) {
-    return levels[level - 1];
+    if (level > 0 && level < levels.length + 1) {
+      return levels[level - 1];
+    }
+    return null;
   }
 
   List<LevelConfiguration> get levels => [
-    level1,
-    level2,
-  ];
-
-  LevelConfiguration get level1 => new LevelConfiguration(dimensions: _dimensions)
-      ..level = 1
-      ..landscape = new LandscapeConfig(
-        width: _dimensions.width,
-        height: _dimensions.height,
-        x: _dimensions.width / 2,
-        y: _dimensions.height / 2,
-      )
-      ..arrow = _defaultArrowConfig
-      ..crates = [
-        new CrateConfig()
-          ..x = 500.0
-          ..y = _height - 198,
-      ]
-      ..platforms = [
-        new PlatformConfig()
-          ..x = 500.0
-          ..y = _height - 110,
+        level1,
+        level2,
+        level3,
       ];
 
-  LevelConfiguration get level2 => new LevelConfiguration(dimensions: _dimensions)
-      ..level = 2
-      ..landscape = new LandscapeConfig(
-        width: _dimensions.width,
-        height: _dimensions.height,
-        x: _dimensions.width / 2,
-        y: _dimensions.height / 2,
-      )
-      ..arrow = _defaultArrowConfig
-      ..crates = [
-        new CrateConfig()
-          ..x = 2000.0
-          ..y = _height - 198,
-        new CrateConfig()
-          ..x = 1600.0
-          ..y = _height - 198,
-        new CrateConfig()
-          ..x = 700.0
-          ..y = _height - 198,
-      ]
-      ..platforms = [
-        new PlatformConfig()
-          ..x = 2000.0
-          ..y = _height - 110,
-        new PlatformConfig()
-          ..x = 1600.0
-          ..y = _height - 110,
-        new PlatformConfig()
-          ..x = 700.0
-          ..y = _height - 110,
-      ];
+  LevelConfiguration get level1 =>
+      new LevelConfiguration(dimensions: _dimensions)
+        ..level = 1
+        ..landscape = new LandscapeConfig(
+          width: _dimensions.width,
+          height: _dimensions.height,
+          x: _dimensions.width / 2,
+          y: _dimensions.height / 2,
+        )
+        ..arrow = _defaultArrowConfig
+        ..crates = [
+          new CrateConfig()
+            ..x = 500.0
+            ..y = _height - 198,
+        ]
+        ..platforms = [
+          new PlatformConfig()
+            ..x = 500.0
+            ..y = _height - 110,
+        ];
 
-  LevelConfiguration get level3 => new LevelConfiguration(dimensions: _dimensions)
-      ..level = 3
-      ..landscape = new LandscapeConfig(
-        width: _dimensions.width,
-        height: _dimensions.height,
-        x: _dimensions.width / 2,
-        y: _dimensions.height / 2,
-      )
-      ..arrow = _defaultArrowConfig
-      ..crates = [
-        new CrateConfig()
-          ..x = 2000.0
-          ..y = _height - 198,
-        new CrateConfig()
-          ..x = 1600.0
-          ..y = _height - 198,
-        new CrateConfig()
-          ..x = 700.0
-          ..y = _height - 198,
-        new CrateConfig()
-          ..x = 2000.0
-          ..y = _height - 198,
-        new CrateConfig()
-          ..x = 1600.0
-          ..y = _height - 198,
-        new CrateConfig()
-          ..x = 700.0
-          ..y = _height - 198,
-      ]
-      ..platforms = [
-        new PlatformConfig()
-          ..x = 2000.0
-          ..y = _height - 110,
-        new PlatformConfig()
-          ..x = 1600.0
-          ..y = _height - 110,
-        new PlatformConfig()
-          ..x = 700.0
-          ..y = _height - 110,
-      ];
+  LevelConfiguration get level2 =>
+      new LevelConfiguration(dimensions: _dimensions)
+        ..level = 2
+        ..landscape = new LandscapeConfig(
+          width: _dimensions.width,
+          height: _dimensions.height,
+          x: _dimensions.width / 2,
+          y: _dimensions.height / 2,
+        )
+        ..arrow = _defaultArrowConfig
+        ..crates = [
+          new CrateConfig()
+            ..x = 2000.0
+            ..y = _height - 198,
+          new CrateConfig()
+            ..x = 1600.0
+            ..y = _height - 198,
+          new CrateConfig()
+            ..x = 700.0
+            ..y = _height - 198,
+        ]
+        ..platforms = [
+          new PlatformConfig()
+            ..x = 2000.0
+            ..y = _height - 110,
+          new PlatformConfig()
+            ..x = 1600.0
+            ..y = _height - 110,
+          new PlatformConfig()
+            ..x = 700.0
+            ..y = _height - 110,
+        ];
+
+  LevelConfiguration get level3 =>
+      new LevelConfiguration(dimensions: _dimensions)
+        ..level = 3
+        ..landscape = new LandscapeConfig(
+          width: _dimensions.width,
+          height: _dimensions.height,
+          x: _dimensions.width / 2,
+          y: _dimensions.height / 2,
+        )
+        ..arrow = _defaultArrowConfig
+        ..crates = [
+          new CrateConfig()
+            ..x = 1600.0
+            ..y = _height - 198,
+          new CrateConfig()
+            ..x = 700.0
+            ..y = _height - 198,
+          new CrateConfig()
+            ..x = 1000.0
+            ..y = _height - 500,
+          new CrateConfig()
+            ..x = 1150.0
+            ..y = _height - 500,
+          new CrateConfig()
+            ..x = 1300.0
+            ..y = _height - 500,
+
+        ]
+        ..platforms = [
+          new PlatformConfig()
+            ..x = 1600.0
+            ..y = _height - 110,
+          new PlatformConfig()
+            ..x = 700.0
+            ..y = _height - 110,
+          new PlatformConfig()
+            ..x = 1134.0
+            ..y = _height - 420
+        ];
 
   ArrowConfig get _defaultArrowConfig => new ArrowConfig()
     ..x = 300.0

--- a/lib/screens/constants.dart
+++ b/lib/screens/constants.dart
@@ -1,4 +1,4 @@
 class AppSharedPrefs {
   static const String showGuides = "SHOW_GUIDES";
-  static const String levelOverride = "LEVEL_OVERRIDE";
+  static const String currentLevel = "LEVEL_OVERRIDE";
 }

--- a/lib/screens/screens.dart
+++ b/lib/screens/screens.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:angry_arrows/data/firebase_adapter.dart';
 import 'package:angry_arrows/game/game.dart';
@@ -70,8 +71,12 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
-  void _handleStartOnPress() =>
-      loadGameScene(widget.levels, 1, firebase.writeScore);
+  Future<Null> _handleStartOnPress() async {
+    var prefs = await SharedPreferences.getInstance();
+    var currentLevel = prefs.getInt(AppSharedPrefs.currentLevel) ?? 1;
+    currentLevel = math.min(currentLevel, widget.levels.levels.length);
+    loadGameScene(widget.levels, currentLevel, firebase.writeScore);
+  }
 
   void _handleLevelsOnPress() {
     Navigator.of(context).push(
@@ -177,9 +182,10 @@ class _LevelsScreenState extends State<LevelsScreen> {
           scaffoldContext: c)
     ];
 
+    var currentLevel = prefs.getInt(AppSharedPrefs.currentLevel) ?? 1;
     for (var i = 1; i <= 30; i++) {
       var isValid = i - 1 < widget.levels.levels.length;
-      var isEnabled = i <= (prefs?.getInt(AppSharedPrefs.levelOverride) ?? 2);
+      var isEnabled = i <= currentLevel;
 
       levelPreviews.add(
         new BoxItem(
@@ -260,9 +266,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
               children: <Widget>[
                 new Text("Show launch guides"),
                 new Checkbox(
-                  value: prefs.getBool("SHOW_GUIDES") ?? true,
-                  onChanged: (nextValue) =>
-                      setState(() => prefs.setBool("SHOW_GUIDES", nextValue)),
+                  value: prefs.getBool(AppSharedPrefs.showGuides) ?? true,
+                  onChanged: (nextValue) => setState(() =>
+                      prefs.setBool(AppSharedPrefs.showGuides, nextValue)),
                 ),
               ],
             ),
@@ -272,14 +278,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
               children: <Widget>[
                 new Text("Override current level"),
                 new Slider(
-                  value: prefs.getInt("CURRENT_LEVEL_INT")?.toDouble() ?? 2.0,
+                  value:
+                      prefs.getInt(AppSharedPrefs.currentLevel)?.toDouble() ??
+                          1.0,
                   min: 1.0,
                   max: 30.0,
                   divisions: 30,
-                  label: prefs.getInt("CURRENT_LEVEL_INT").toString(),
+                  label: (prefs.getInt(AppSharedPrefs.currentLevel) ?? 1).toString(),
                   thumbOpenAtMin: true,
-                  onChanged: (nextValue) => setState(() =>
-                      prefs.setInt("CURRENT_LEVEL_INT", nextValue.toInt())),
+                  onChanged: (nextValue) => setState(() => prefs.setInt(
+                      AppSharedPrefs.currentLevel, nextValue.toInt())),
                 ),
               ],
             ),


### PR DESCRIPTION
Game now displays the score (which I've also used as "remaining arrows") in the bottom left.

**Level switching changes**
- Added a third level
- On completion of a level, the game takes you to the next level (or to the menu if there is none)
- When the user's score hits 0 (ie, they run out of remaining arrows), the level resets.
- The level override preference is now just "current level" (the string value did not change)
- Pressing the start button now loads the current level, not just level 1.


Also, I removed the call to `_resetArrow` when arrows collide with crates.  This change allows for arrows to hit multiple boxes on one flight, which I feel will give users _a sense of pride and accomplishment_. 